### PR TITLE
Add shell.nix

### DIFF
--- a/nix-shell/shell.nix
+++ b/nix-shell/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+(pkgs.buildFHSUserEnv {
+  name = "bazel-userenv-example";
+  targetPkgs = pkgs: [
+    pkgs.bazel
+    pkgs.glibc
+  ];
+}).env


### PR DESCRIPTION
The build succeeds, but it doesn't really compile
anything, so I guess there's still something missing
on the bazel side? Or should I invoke some other
command?

```
$ bazel build
WARNING: Usage: bazel build <options> <targets>.
Invoke `bazel help build` for full description of usage and options.
Your request is correct, but requested an empty set of targets. Nothing will be built.
INFO: Analyzed 0 targets (0 packages loaded, 0 targets configured).
INFO: Found 0 targets...
INFO: Elapsed time: 0.055s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```